### PR TITLE
Add a 'hide' parameter to guide index.qmd and add filter in the template

### DIFF
--- a/guide/component/index.qmd
+++ b/guide/component/index.qmd
@@ -1,4 +1,5 @@
 ---
 title: Component
 order: 10
+hidden: true
 ---

--- a/guide/nextflow_vdsl3/index.qmd
+++ b/guide/nextflow_vdsl3/index.qmd
@@ -1,4 +1,5 @@
 ---
 title: Nextflow VDSL3
 order: 30
+hidden: true
 ---

--- a/guide/project/index.qmd
+++ b/guide/project/index.qmd
@@ -1,4 +1,5 @@
 ---
 title: Project
 order: 20
+hidden: true
 ---

--- a/guide/template.ejs
+++ b/guide/template.ejs
@@ -1,9 +1,11 @@
 ```{=html}
 <ul>
 <% for (const item of items) { %>
-  <li>
-    <a href="<%- item.path %>"><%= item.title %></a>: <%= item.description %>
-  </li>
+  <% if (!item.hidden) { %>
+    <li>
+      <a href="<%- item.path %>"><%= item.title %></a>: <%= item.description %>
+    </li>
+  <% } %>
 <% } %>
 </ul>
 ```


### PR DESCRIPTION
The page is only added to the listing if the .hidden parameter is not set. This still links the index.qmd page in the sidebar though.