### PR TITLE
Reorder platform pages. Fixes #34

### DIFF
--- a/_src/automation/config_pages_settings.yaml
+++ b/_src/automation/config_pages_settings.yaml
@@ -44,6 +44,10 @@ structure:
 order:
   './config': 20
   './project': 30
+  'platforms/nativePlatform': 10
+  'platforms/dockerPlatform': 20
+  'platforms/nextflowVdsl3Platform': 30
+  'platforms/nextflowLegacyPlatform': 40
 
 keywords:
   mykeyword: /reference/config.html

--- a/reference/config/platforms/docker/_index.yaml
+++ b/reference/config/platforms/docker/_index.yaml
@@ -270,5 +270,6 @@ data:
     format: yaml
   name: chown
   type: Boolean
+order: 20
 title: Docker Platform
 topic: platforms

--- a/reference/config/platforms/docker/index.qmd
+++ b/reference/config/platforms/docker/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Docker Platform"
 search: true
+order: 20
 ---
 
 Run a Viash component on a Docker backend platform.

--- a/reference/config/platforms/native/_index.yaml
+++ b/reference/config/platforms/native/_index.yaml
@@ -23,5 +23,6 @@ data:
 - description: Specifies the type of the platform.
   name: type
   type: String
+order: 10
 title: Native Platform
 topic: platforms

--- a/reference/config/platforms/native/index.qmd
+++ b/reference/config/platforms/native/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Native Platform"
 search: true
+order: 10
 ---
 
 Running a Viash component on a native platform means that the script will be executed in your current environment.

--- a/reference/config/platforms/nextflow/_index.yaml
+++ b/reference/config/platforms/nextflow/_index.yaml
@@ -49,5 +49,6 @@ data:
 - description: Specifies the type of the platform.
   name: type
   type: String
+order: 30
 title: Nextflow Vdsl3 Platform
 topic: platforms

--- a/reference/config/platforms/nextflow/index.qmd
+++ b/reference/config/platforms/nextflow/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Nextflow Vdsl3 Platform"
 search: true
+order: 30
 ---
 
 Next-gen platform for generating NextFlow VDSL3 modules.

--- a/reference/config/platforms/nextflowLegacy/_index.yaml
+++ b/reference/config/platforms/nextflowLegacy/_index.yaml
@@ -203,5 +203,6 @@ data:
     message: Undocumented & stale value
     removal: 0.7.0
   type: Option of String
+order: 40
 title: Nextflow Legacy Platform
 topic: platforms

--- a/reference/config/platforms/nextflowLegacy/index.qmd
+++ b/reference/config/platforms/nextflowLegacy/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Nextflow Legacy Platform"
 search: true
+order: 40
 ---
 
 ::: {.callout-warning}


### PR DESCRIPTION
Page ordering is fixed in Quarto 1.3 so now we can order platform pages too.