### PR TITLE
Rename dropdown from "Latest" to 0.8.6

### DIFF
--- a/versions.js
+++ b/versions.js
@@ -2,7 +2,6 @@ function createVersionLink(version) {
   var tag = document.createElement("li");
   var link = document.createElement("a");
   link.setAttribute("class", "dropdown-item");
-  // link.setAttribute("href", "/versioned/" + version.link + "/");
   link.setAttribute("rel", "");
   link.setAttribute("target", "");
   link.addEventListener("click", function() { versionClick(version.link) });
@@ -11,22 +10,6 @@ function createVersionLink(version) {
   span.setAttribute("class", "dropdown-text");
   link.appendChild(span);
   span.innerHTML = version.name;
-  return tag;
-}
-
-function createLatestLink() {
-  var tag = document.createElement("li");
-  var link = document.createElement("a");
-  link.setAttribute("class", "dropdown-item");
-  // link.setAttribute("href", "/");
-  link.setAttribute("rel", "");
-  link.setAttribute("target", "");
-  link.addEventListener("click", function() { versionClick("") });
-  tag.appendChild(link);
-  var span = document.createElement("span");
-  span.setAttribute("class", "dropdown-text");
-  link.appendChild(span);
-  span.innerHTML = "Latest";
   return tag;
 }
 
@@ -72,7 +55,6 @@ function setVersionLinks(json) {
   // Populate the version drowdown
   var dropdownElement = document.getElementById("nav-menu-version");
   var list = dropdownElement.nextElementSibling;
-  list.appendChild( createLatestLink() );
   for (var i = 0; i < json.versions.length; i++) {
     var version = json.versions[i];
     list.appendChild( createVersionLink(version) );

--- a/versions.json
+++ b/versions.json
@@ -2,6 +2,10 @@
   "latest": "0.8.6",
   "versions": [
     {
+      "name": "Viash 0.8.6",
+      "link": ""
+    },
+    {
       "name": "Viash 0.8.5",
       "link": "0_8_5"
     },

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "latest": "0.8.6",
   "versions": [
     {
-      "name": "Viash 0.8.6",
+      "name": "Viash 0.8.6 (Latest)",
       "link": ""
     },
     {


### PR DESCRIPTION
Noticed that we don't need 2 separate almost identical methods and just one can be used by setting link to ""