### PR TITLE
fix 0.9.0 not being latest anymore, version dropdown name updating

### DIFF
--- a/_src/version_copy.sh
+++ b/_src/version_copy.sh
@@ -1,0 +1,5 @@
+mkdir _versioned/new
+rsync -av --exclude 'versions.js' --exclude 'versions.json' --exclude 'versioned' _site/ _versioned/new/
+
+echo "next rename the 'new' folder to the version number"
+echo "then run 'tar -cJf new.tar.xz new'"

--- a/versions.js
+++ b/versions.js
@@ -63,6 +63,22 @@ function setVersionLinks(json) {
   // Alter the navbar logo link to point to the root
   var navbarElements = document.getElementsByClassName("navbar-brand");
   navbarElements[0].setAttribute("href", "/");
+
+  // Alter the version dropdown to show the displayed version
+  var url = window.location.pathname;
+  var urlParts = url.split("/");
+  var versionPath = "";
+  if (urlParts.length > 3 && urlParts[1] == "versioned") {
+    versionPath = urlParts[2];
+  }
+  for (var i = 0; i < json.versions.length; i++) {
+    var version = json.versions[i];
+    if (version.link == versionPath) {
+      var dropdownElement = document.getElementById("nav-menu-version");
+      dropdownElement.innerHTML = version.name;
+      break;
+    }
+  }
 }
 
 fetch('/versions.json')

--- a/versions.json
+++ b/versions.json
@@ -6,7 +6,7 @@
       "link": ""
     },
     {
-      "name": "Viash 0.9.0 (Latest)",
+      "name": "Viash 0.9.0",
       "link": "0_9_0"
     },
     {


### PR DESCRIPTION
fix 0.9.0 not being latest anymore
after page update, check what version we're displaying, match it with the versions.json and display the name as the version dropdown